### PR TITLE
Casting quality to string when setting keys of 'bucket' array …

### DIFF
--- a/src/AbstractNegotiator.php
+++ b/src/AbstractNegotiator.php
@@ -195,7 +195,7 @@ abstract class AbstractNegotiator implements IteratorAggregate
 
         // sort into q-value buckets
         foreach ($this->acceptable as $value) {
-            $bucket[$value->getQuality()][] = $value;
+            $bucket[(string)$value->getQuality()][] = $value;
         }
 
         // reverse-sort the buckets so that q=1 is first and q=0 is last,

--- a/tests/MediaTest.php
+++ b/tests/MediaTest.php
@@ -121,6 +121,13 @@ class MediaTest extends AcceptTestCase
                 'expected_value' => '*/*',
                 'expected_params' => array(),
             ),
+            array(
+                // check that quality values are properly sorted
+                'server' => array('HTTP_ACCEPT' => 'application/yaml;q=.1,application/json;q=.3,application/xml;q=.2'),
+                'available' => array('application/yaml', 'application/json', 'application/xml'),
+                'expected_value' => 'application/json',
+                'expected_params' => array()
+            )
         );
     }
 


### PR DESCRIPTION
… in sort method

Previously, the bucket array would end up with only 1 entry with a key of 0 since floats
are cast to integers in array keys (http://stackoverflow.com/a/4542273/1725265)

---

Given this Accept header:
string(64) "application/yaml;q=.1,application/json;q=.3,application/xml;q=.2"

Expected negotiated media type: "application/json"

---

Before change:

array_keys($bucket)
Before krsort: [0] 
After krsort: [0]

Negotiated media type:
string(16) "application/yaml"

---

After change:

array_keys($bucket)
Before krsort: ["0.1","0.3","0.2"] 
After krsort: ["0.3","0.2","0.1"]

Negotiated media type:
string(16) "application/json"
