### PR TITLE
added phpunit 5 via composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - composer self-update
   - composer install
 script:
-  - phpunit --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Alternatively, [download a release](https://github.com/auraphp/Aura.Accept/relea
 [![Code Coverage](https://scrutinizer-ci.com/g/auraphp/Aura.Accept/badges/coverage.png?b=develop-2)](https://scrutinizer-ci.com/g/auraphp/Aura.Accept/)
 [![Build Status](https://travis-ci.org/auraphp/Aura.Accept.png?branch=develop-2)](https://travis-ci.org/auraphp/Aura.Accept)
 
-To run the unit tests at the command line, issue `composer install` and then `phpunit` at the package root. This requires [Composer](http://getcomposer.org/) to be available as `composer`, and [PHPUnit](http://phpunit.de/manual/) to be available as `phpunit`.
+To run the [PHPUnit](http://phpunit.de/manual/) unit tests at the command line, issue `composer install` and then `vendor/bin/phpunit` at the package root. This requires [Composer](http://getcomposer.org/) to be available as `composer`.
 
 This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If
 you notice compliance oversights, please send a patch via pull request.

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         }
     },
     "require-dev": {
-        "aura/di": "~2.0"
+        "aura/di": "~2.0",
+        "phpunit/phpunit":"~5.6"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "aura/di": "~2.0",
-        "phpunit/phpunit":"~5.6"
+        "phpunit/phpunit":"~5.7 || ~4.8"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
using the latest phpunit (version 6) fails because of a change in class names:
PHPUnit_Framework_TestCase is now PHPUnit\Framework\TestCase
using version 5 via require-dev will ensure that tests are ran with a working copy

with this change, tests can be ran with 'vendor/bin/phpunit' from the package root