### PR TITLE
Back to 7.2 for consistency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,8 @@ jobs:
         operating-system:
           - ubuntu-latest
         php-version:
+          - '7.2'
+          - '7.3'
           - '7.4'
           - '8.0'
           - '8.1'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provides content-negotiation tools using `Accept*` headers.
 
 ### Installation
 
-This library requires PHP 7.2 or later;  it has been tested on PHP 7.4-8.1. we recommend using the latest available version of PHP as a matter of principle. It has no userland dependencies.
+This library requires PHP 7.2 or later;  it has been tested on PHP 7.2 - 8.1. we recommend using the latest available version of PHP as a matter of principle. It has no userland dependencies.
 
 It is installable and autoloadable via Composer as [aura/accept](https://packagist.org/packages/aura/accept).
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4"
+        "php": "^7.2 || ^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -28,7 +28,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/AcceptTest.php
+++ b/tests/AcceptTest.php
@@ -1,11 +1,11 @@
 <?php
 namespace Aura\Accept;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class AcceptTest extends TestCase
 {
-    protected function setup(): void
+    protected function set_up()
     {
         $factory = new AcceptFactory(array(
             'HTTP_ACCEPT' => 'application/json, application/xml, text/*, */*',

--- a/tests/AcceptTestCase.php
+++ b/tests/AcceptTestCase.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Accept;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class AcceptTestCase extends TestCase
 {


### PR DESCRIPTION
I know I proposed the change to move to 7.4 for not released packages.

After some thoughts, I think we can stick to 7.2 for 4.x . So there is no confusion for the 4.x php version and 5.x versions as we move forward.