### PR TITLE
Fixed PHP Deprecated Implicitly marking parameter $available as nullable

### DIFF
--- a/src/AbstractNegotiator.php
+++ b/src/AbstractNegotiator.php
@@ -239,7 +239,7 @@ abstract class AbstractNegotiator implements IteratorAggregate
      * `$available` value objects on success, or false on failure.
      *
      */
-    public function negotiate(array $available = null)
+    public function negotiate(?array $available = null)
     {
         // if none available, no possible match
         if (! $available) {


### PR DESCRIPTION
Changed to be explicitly marked as nullable, this is a fix for PHP 8.4